### PR TITLE
Add read_all method

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           python -m pip install \
             setuptools \
-            numpy \
+            "numpy<2" \
             matplotlib \
             scipy \
             h5py

--- a/OrvilleImageDB.py
+++ b/OrvilleImageDB.py
@@ -513,7 +513,7 @@ class OrvilleImageDB(object):
             mask = numpy.fromfile(self.file, 'u1', nchan)
             reshaped_mask = numpy.full(data.shape, False, dtype=bool) # Create Bool array filled with False values
             reshaped_mask[numpy.argwhere(mask),...] = True # Propagate True across rows of flagged channels
-            data = numpy.ma.masked_array(data, reshaped_mask) # Create masked array
+            data = numpy.ma.masked_array(data, reshaped_mask, dtype=numpy.float32) # Create masked array
             
         self.curr_int += 1
         return info, data
@@ -521,7 +521,7 @@ class OrvilleImageDB(object):
     def read_all(self):
         self.seek(0)
         nchan, nstokes, ngrid = self.header.nchan, self.nstokes, self.header.ngrid
-        data_all = numpy.ma.zeros((self.nint, nchan, nstokes, ngrid, ngrid))
+        data_all = numpy.ma.zeros((self.nint, nchan, nstokes, ngrid, ngrid), dtype=numpy.float32)
         hdr_list = []
         while self.curr_int < self.nint:
             hdr, data = self.read_image()

--- a/OrvilleImageDB.py
+++ b/OrvilleImageDB.py
@@ -513,7 +513,7 @@ class OrvilleImageDB(object):
             mask = numpy.fromfile(self.file, 'u1', nchan)
             reshaped_mask = numpy.full(data.shape, False, dtype=bool) # Create Bool array filled with False values
             reshaped_mask[numpy.argwhere(mask),...] = True # Propagate True across rows of flagged channels
-            data = numpy.ma.masked_array(data, reshaped_mask, dtype=numpy.float32) # Create masked array
+            data = numpy.ma.masked_array(data, reshaped_mask, dtype=data.dtype) # Create masked array
             
         self.curr_int += 1
         return info, data

--- a/OrvilleImageDB.py
+++ b/OrvilleImageDB.py
@@ -512,9 +512,8 @@ class OrvilleImageDB(object):
         if self.include_mask:
             mask = numpy.fromfile(self.file, 'u1', nchan)
             reshaped_mask = numpy.full(data.shape, False, dtype=bool) # Create Bool array filled with False values
-            reshaped_mask[numpy.argwhere(mask),...] = True # Propogate True across rows of flagged channels
-            data = numpy.ma.array(data) # Create masked array the same way
-            data.mask = reshaped_mask # Append new mask            
+            reshaped_mask[numpy.argwhere(mask),...] = True # Propagate True across rows of flagged channels
+            data = numpy.ma.masked_array(data, reshaped_mask) # Create masked array
             
         self.curr_int += 1
         return info, data

--- a/OrvilleImageDB.py
+++ b/OrvilleImageDB.py
@@ -518,6 +518,17 @@ class OrvilleImageDB(object):
         self.curr_int += 1
         return info, data
         
+    def read_all(self):
+        self.seek(0)
+        nchan, nstokes, ngrid = self.header.nchan, self.nstokes, self.header.ngrid
+        data_all = numpy.ma.zeros((self.nint, nchan, nstokes, ngrid, ngrid))
+        hdr_list = []
+        while self.curr_int < self.nint:
+            hdr, data = self.read_image()
+            hdr_list.append(hdr)
+            data_all[self.curr_int-1] = data
+        return hdr_list, data_all
+        
     @staticmethod
     def sort(filename):
         """

--- a/OrvilleImageDB.py
+++ b/OrvilleImageDB.py
@@ -519,6 +519,32 @@ class OrvilleImageDB(object):
         return info, data
         
     def read_all(self):
+        """
+        Reads all integrations from the database.
+        
+        Returns a 2-tuple containing:
+        hdr_list -- a list of dictionaries with the following keys defined:
+            start_time -- MJD UTC at which this integration began
+            int_len -- integration length, in days
+            fill -- packet fill fraction, if available
+            lst -- mean local sidereal time of the observation, in days
+            start_freq -- frequency of first channel in the integration, in Hz
+            stop_freq -- frequency of last channel in the integration, in Hz
+            bandwidth -- bandwidth of each channel in the integrated data, in Hz
+            center_ra -- RA of the image phase center, in degrees
+            center_dec -- Declination of image phase center, in degrees
+            center_az -- azimuth of the image phase center, in degrees
+            center_alt -- altitude of image phase center, in degrees
+            asp_filter -- ASP filter code (0=split, 1=full, ...)
+            asp_atten_1 -- ASP first attenuator setting
+            asp_atten_2 -- ASP second attenuator setting
+            asp_atten_s -- ASP split attenuator setting
+            pixel_size -- Real-world size of a pixel, in degrees
+            stokes_params -- a list or comma-delimited string of Stokes params
+        data_all -- a 5D masked float32 array of image data indexed as 
+            [integration, chan, stokes, x, y]
+        """
+        
         self.seek(0)
         nchan, nstokes, ngrid = self.header.nchan, self.nstokes, self.header.ngrid
         data_all = numpy.ma.zeros((self.nint, nchan, nstokes, ngrid, ngrid), dtype=numpy.float32)

--- a/README.md
+++ b/README.md
@@ -41,15 +41,22 @@ ngrid = db.header.ngrid # image size (x-axis)
 psize = db.header.pixel_size # angular size of a pixel (at zenith)
 nchan = db.header.nchan # number of frequency channels
 
-# Collect header and data from the whole file
+# There are two main ways to read data from the OIMS file:
+#  - From a single integration
+#  - From all integrations at once
 
-for i,(hdr,data) in enumerate(db):
-    print(i, hdr)
-
-# Below will give more info on the headers and data array
-# Collecting data and header from a particular image integration (Usually 720 integrations (each 5 seconds) in an hour) 
+# 1. Reading a particular image integration
+#    (Usually 720 integrations (each 5 seconds) in an hour) 
 
 hdr, dat = db.__getitem__(710) # collecting header and data from the 710 th integration
+
+# The dat array contains the image data in a four dimensional array of the form [nchan,stokes,xgrid,ygrid]
+# where nchan = 198 frequency channels, stokes = 4 [stokes (I, Q, U,V)], xgrid = grid size in the x direction,
+# ygrid = grid size in the y direction (typically xgrid = ygrid = ngrid)
+# Copy over to numpy arrays for further processing (e.g. image subtraction and transient searches).
+
+# Individual header items can be accessed from the hdr dictionary:
+
 t = hdr['start_time'] # starting time in MJD
 int_len = hdr['int_len'] # length of each integration
 lst = hdr['lst'] # starting LST time of observation
@@ -61,10 +68,19 @@ cent_dec = hdr['center_dec'] # phase center Dec
 cent_az = hdr['center_az']   # phase center coordinates, azimuth, Ideally towards zenith, changed due to w-projection 
 cent_alt = hdr['center_alt'] # phase center coordinates, elevation, Ideally towards zenith, changed due to w-projection 
 
-# The dat array contains the image data in a four dimensional array of the form [nchan,stokes,xgrid,ygrid]
-# where nchan = 198 frequency channels, stokes = 4 [stokes (I, Q, U,V)], xgrid = grid size in the x direction,
-# ygrid = grid size in the y direction and mostly xgrid = ygrid = ngrid
-# Copy over to numpy arrays for further processing such as image subtraction and transient searches.
 
+# 2. Reading all integrations at once
+
+hdr_list, data_all = db.read_all()
+
+# data_all contains the image data in a 5d masked array of the form [integration,nchan,stokes,xgrid,ygrid]
+# where integration is the number of integrations (typically 720 per hour) and the other axes are the same
+# as above. hdr_list is a list of dictionaries, one per integration. This can easily be converted to a 
+# pandas dataframe object by doing:
+
+import pandas as pd
+hdr_df = pd.DataFrame(hdr_list)
+
+# Close the database file
 db.close()
 ```

--- a/tests/test_oims.py
+++ b/tests/test_oims.py
@@ -51,6 +51,25 @@ class oims_tests(unittest.TestCase):
         
         db.close()
         
+    def test_oims_read_all(self):
+        """Test reading in all images from a OrvilleImage file."""
+
+        db = OrvilleImageDB.OrvilleImageDB(oimsFile, 'r')
+        
+        # Read in the first image with the correct number of elements
+        hdrs, data = db.read_all()
+        ## Count
+        self.assertEqual(len(hdrs), 13)
+        self.assertEqual(len(hdrs), len(data))
+        ## Image
+        for d in data:
+            self.assertEqual(d.shape[0], db.header.nchan)
+            self.assertEqual(d.shape[1], len(db.header.stokes_params.split(b',')))
+            self.assertEqual(d.shape[2], db.header.ngrid)
+            self.assertEqual(d.shape[3], db.header.ngrid)
+        
+        db.close()
+        
     def test_oims_loop(self):
         """Test reading in a collection of images in a loop."""
         


### PR DESCRIPTION
I've added a `read_all` method to `OrvilleImageDB.py` which reads in all integrations at once and returns the headers in a list of dicts and the data in a 5d masked float32 array. Changing the masking process and array dtypes sped up the process about 3-4 times compared to the original iterative technique. 